### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/m-kuhn/vcpkg-pre-commit
+  rev: v0.1.0
+  hooks:
+  - id: vcpkg-format

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ Enable registries feature flag in vcpkg and write a vcpkg-configuration.json fil
 ## Contributions
 
 Contributions are very welcome 👋
+
+### Using pre-commit hook to automatically format files
+
+Install and enable pre-commit in your local git clone to automatically
+have manifest files formatted whenever you `git commit` something.
+
+```console
+pip install pre-commit
+pre-commit install
+```


### PR DESCRIPTION
Quality of life improvement

### Using pre-commit hook to automatically format files

Install and enable pre-commit in your local git clone to automatically
have manifest files formatted whenever you `git commit` something.

```console
pip install pre-commit
pre-commit install
```