### PR TITLE
Fix py-lxml

### DIFF
--- a/ports/py-lxml/portfile.cmake
+++ b/ports/py-lxml/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_pythonhosted(
     SHA512          7f8a3717645893bc6f790cc9adfb8fdab91c352dc4dc23c0ccb4af9a0d138acf9ef5054e9786af497955f10079e9242dbd63ea9ac39c33bfd71ca2fe4ef4a7c0
 )
 
+set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
+
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/py-lxml/portfile.cmake
+++ b/ports/py-lxml/portfile.cmake
@@ -5,7 +5,9 @@ vcpkg_from_pythonhosted(
     SHA512          7f8a3717645893bc6f790cc9adfb8fdab91c352dc4dc23c0ccb4af9a0d138acf9ef5054e9786af497955f10079e9242dbd63ea9ac39c33bfd71ca2fe4ef4a7c0
 )
 
-set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
+if(VCPKG_TARGET_IS_WINDOWS)
+  set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
+endif()
 
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")
 

--- a/ports/py-lxml/vcpkg.json
+++ b/ports/py-lxml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-lxml",
   "version": "5.3.0",
+  "port-version": 1,
   "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
   "homepage": "https://lxml.de/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -102,7 +102,7 @@
     },
     "py-lxml": {
       "baseline": "5.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-markupsafe": {
       "baseline": "3.0.2",

--- a/versions/p-/py-lxml.json
+++ b/versions/p-/py-lxml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4fdde6a73b528aa740f6856bb432dfa915ca6e0",
+      "version": "5.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4484db34ac967ae57178fecde9d5b3cd94a551cf",
       "version": "5.3.0",
       "port-version": 0


### PR DESCRIPTION
Add include dir to env

Needed to build py-lxml which is needed by MetaSearch plugin in QGIS