### PR TITLE
Add wrapper scripts for windows for python scripts

### DIFF
--- a/ports/py-sip/portfile.cmake
+++ b/ports/py-sip/portfile.cmake
@@ -13,12 +13,12 @@ vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/${python_versioned}/site-packages/pyqtbuild/bundle/dlls/)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-build")
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-distinfo")
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-install")
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-module")
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-sdist")
-  vcpkg_fixup_shebang(SCRIPT "bin/sip-wheel")
+  vcpkg_fixup_shebang(SCRIPT "sip-build" MODULE "sipbuild.tools.build")
+  vcpkg_fixup_shebang(SCRIPT "sip-distinfo" MODULE "sipbuild.tools.distinfo")
+  vcpkg_fixup_shebang(SCRIPT "sip-install" MODULE "sipbuild.tools.install")
+  vcpkg_fixup_shebang(SCRIPT "sip-module" MODULE "sipbuild.tools.module")
+  vcpkg_fixup_shebang(SCRIPT "sip-sdist" MODULE "sipbuild.tools.sdist")
+  vcpkg_fixup_shebang(SCRIPT "sip-wheel" MODULE "sipbuild.tools.wheel")
 endif()
 
 

--- a/ports/py-sip/vcpkg.json
+++ b/ports/py-sip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-sip",
   "version": "6.10.0",
+  "port-version": 1,
   "description": "A tool that makes it easy to create Python bindings for C and C++ libraries",
   "homepage": "https://www.riverbankcomputing.com/software/sip",
   "dependencies": [

--- a/ports/vcpkg-python-scripts/vcpkg.json
+++ b/ports/vcpkg-python-scripts/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vcpkg-python-scripts",
-  "version-date": "2024-05-12",
-  "port-version": 3,
+  "version-date": "2025-05-20",
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT",
   "supports": "native",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -270,7 +270,7 @@
     },
     "py-sip": {
       "baseline": "6.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-six": {
       "baseline": "1.16.0",
@@ -325,8 +325,8 @@
       "port-version": 1
     },
     "vcpkg-python-scripts": {
-      "baseline": "2024-05-12",
-      "port-version": 3
+      "baseline": "2025-05-20",
+      "port-version": 0
     },
     "vcpkg-tool-mercurial": {
       "baseline": "2023-06-27",

--- a/versions/p-/py-sip.json
+++ b/versions/p-/py-sip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e4be4b4aa9b7226babe595cdd482fdd6fa530d9",
+      "version": "6.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f00e67555511b8233716e0eca5b62741751f8bf9",
       "version": "6.10.0",
       "port-version": 0

--- a/versions/v-/vcpkg-python-scripts.json
+++ b/versions/v-/vcpkg-python-scripts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa9208882905337e0713103e5612ddd758dc6fab",
+      "version-date": "2025-05-20",
+      "port-version": 0
+    },
+    {
       "git-tree": "6fbcd7ab449af4b41d29aec75c3722b3058e3142",
       "version-date": "2024-05-12",
       "port-version": 3


### PR DESCRIPTION
The entry points of python scripts with a hardcoded absolute path to python, this is not portable. On linux/macos they contain a shebang which we can patch (we already do), on windows, this is an executable which is harder to patch post-build. Others (e.g. conda) does this during installation but we don't have an install step with vcpkg when fetching packages from caches.
Ideally this path should be relative to the executable, how this can be done needs more investigation.
What we do here is, creating a wrapper .bat file that calls python with the main entry point as an alternative to the exe (the exe is still present!)