### PR TITLE
🚀 Auto-update ports 2026-03-16

### DIFF
--- a/ports/py-charset-normalizer/portfile.cmake
+++ b/ports/py-charset-normalizer/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    charset-normalizer
     VERSION         ${VERSION}
-    SHA512          4d58d983a948644d89a25f5563171447c8fadcc252a9a3471d4b5e5ffeff94ddd56bce6a5c3fa84744a15b37b14145f645cef9b1635ef2bfe470abe5e259f55b
+    SHA512          4108b46e103c7b6d1ad3b63f04fdef991246c933cfad05897c0bc3d65b1e5b2aefd9ab50e4d270004a5bfbc0410b8133e0bcab86e9902ff31e6a498d31daeb19
     FILENAME        charset_normalizer
 )
 

--- a/ports/py-charset-normalizer/vcpkg.json
+++ b/ports/py-charset-normalizer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-charset-normalizer",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.",
   "homepage": "https://github.com/Ousret/charset_normalizer",
   "dependencies": [

--- a/ports/py-fonttools/portfile.cmake
+++ b/ports/py-fonttools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    fonttools
     VERSION         ${VERSION}
-    SHA512          f3cd9c65b4fe8b9e3ed5a5390b2505066453bac2438875572183cd3b824b9552206d91729a44408fde98ba0d9bf45cdcd3137c8e6bbcceafa81a3212be4ee981
+    SHA512          002c3912f1c4b6aed45f337c399937f1b56acfd0d812177ca28ee75d67116cf2f68429960dcbef5a8268b2a0f9771aa589cdcba9ef108ceeff490a89cbc856d3
 )
 
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/py-fonttools/vcpkg.json
+++ b/ports/py-fonttools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-fonttools",
-  "version": "4.62.0",
+  "version": "4.62.1",
   "description": "A library to manipulate font files from Python.",
   "homepage": "https://github.com/fonttools/fonttools",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -69,7 +69,7 @@
       "port-version": 0
     },
     "py-charset-normalizer": {
-      "baseline": "3.4.5",
+      "baseline": "3.4.6",
       "port-version": 0
     },
     "py-click": {
@@ -121,7 +121,7 @@
       "port-version": 0
     },
     "py-fonttools": {
-      "baseline": "4.62.0",
+      "baseline": "4.62.1",
       "port-version": 0
     },
     "py-gast": {

--- a/versions/p-/py-charset-normalizer.json
+++ b/versions/p-/py-charset-normalizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f9cb1c5851be4cbfcf0cee44ae68153ccb1b02e",
+      "version": "3.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "edbb2f35c922ba424c4e290e98526ab6c62043fe",
       "version": "3.4.5",
       "port-version": 0

--- a/versions/p-/py-fonttools.json
+++ b/versions/p-/py-fonttools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb918618ddee3d04bef6d6652ab399997170b895",
+      "version": "4.62.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a4cee1591508a501c4be78bd03e2d9bf179ccb5f",
       "version": "4.62.0",
       "port-version": 0


### PR DESCRIPTION
  Summary

✅ Updated (2):
  + py-charset-normalizer (3.4.5 -> 3.4.6)
  + py-fonttools (4.62.0 -> 4.62.1)

📦 Unchanged: 110