### PR TITLE
[gdal] Enable ZSTD support in tiff dependency

### DIFF
--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -22,7 +22,10 @@
     },
     {
       "name": "tiff",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "zstd"
+      ]
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
## Summary
- Adds `zstd` feature to GDAL's tiff dependency so libtiff is built with ZSTD codec support

## Problem
GDAL depends on `tiff` with `default-features: false`, and no GDAL feature propagates `zstd` to the tiff port. This means libtiff is built without ZSTD compression support, causing ZSTD-compressed GeoTIFF files to be unreadable.

The `zstd` feature exists in the tiff port but is not in its default features (defaults are jpeg, lzma, zip).

## Related
- https://github.com/qgis/QGIS/issues/65409
- https://github.com/qgis/QGIS/pull/65803