### PR TITLE
🚀 Auto-update ports 2026-04-29

### DIFF
--- a/ports/py-trove-classifiers/portfile.cmake
+++ b/ports/py-trove-classifiers/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    trove-classifiers
     VERSION         ${VERSION}
-    SHA512          8960c233f6c23d71c33e27d48e0e506314007fb09d5856c4018858f8f28cb4d2e417d16a84e7bb7931489f7f454b41b35a52ff42d88d937fe8447524f07147b5
+    SHA512          11a852886044658b7cb39f55917811b81edff9ca0798630fad20dd8baa195bea4493c8739d472fd9892eba1022e1bd7d52b952b5df43b04dc635163bcbc91f5b
     FILENAME        trove_classifiers
 )
 

--- a/ports/py-trove-classifiers/vcpkg.json
+++ b/ports/py-trove-classifiers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-trove-classifiers",
-  "version": "2026.1.14.14",
+  "version": "2026.4.28.13",
   "description": "Canonical source for classifiers on PyPI (pypi.org).",
   "homepage": "https://github.com/pypa/trove-classifiers",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -441,7 +441,7 @@
       "port-version": 1
     },
     "py-trove-classifiers": {
-      "baseline": "2026.1.14.14",
+      "baseline": "2026.4.28.13",
       "port-version": 0
     },
     "py-typing-extensions": {

--- a/versions/p-/py-trove-classifiers.json
+++ b/versions/p-/py-trove-classifiers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "524c22af9c92d81c908d5c8d2565466890674231",
+      "version": "2026.4.28.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d192fa59c1e3efd894addf0caf55d67b38e18ed",
       "version": "2026.1.14.14",
       "port-version": 0


### PR DESCRIPTION
  Summary

✅ Updated (1):
  + py-trove-classifiers (2026.1.14.14 -> 2026.4.28.13)

📦 Unchanged: 113