### PR TITLE
🚀 Auto-update ports 2026-04-30

### DIFF
--- a/ports/py-flit-core/portfile.cmake
+++ b/ports/py-flit-core/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pypa/flit
     REF ${VERSION}
-    SHA512 ff6df66dfdae6fdf7b277cc3fbb7c9a569103cbe82a3e3ce6f315ec6adec46be8692eba4549a66b3af537d128e6b57ed8f49316b705636466c25674198503643
+    SHA512 1de9358fa33d0924355679ab6bccf5933f2f154257a875dfec7bf88bb569fce487129ff2d7ea13df16287acaedf9da49ce5f9baccd160ebfb6fd33e831e9c9cb
     HEAD_REF main
 )
 

--- a/ports/py-flit-core/vcpkg.json
+++ b/ports/py-flit-core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-flit-core",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "description": "Simplified packaging of Python modules",
   "homepage": "https://flit.pypa.io",
   "license": "BSD-3-Clause",

--- a/ports/py-trove-classifiers/portfile.cmake
+++ b/ports/py-trove-classifiers/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    trove-classifiers
     VERSION         ${VERSION}
-    SHA512          8960c233f6c23d71c33e27d48e0e506314007fb09d5856c4018858f8f28cb4d2e417d16a84e7bb7931489f7f454b41b35a52ff42d88d937fe8447524f07147b5
+    SHA512          11a852886044658b7cb39f55917811b81edff9ca0798630fad20dd8baa195bea4493c8739d472fd9892eba1022e1bd7d52b952b5df43b04dc635163bcbc91f5b
     FILENAME        trove_classifiers
 )
 

--- a/ports/py-trove-classifiers/vcpkg.json
+++ b/ports/py-trove-classifiers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-trove-classifiers",
-  "version": "2026.1.14.14",
+  "version": "2026.4.28.13",
   "description": "Canonical source for classifiers on PyPI (pypi.org).",
   "homepage": "https://github.com/pypa/trove-classifiers",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -121,7 +121,7 @@
       "port-version": 0
     },
     "py-flit-core": {
-      "baseline": "3.12.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "py-fonttools": {
@@ -441,7 +441,7 @@
       "port-version": 1
     },
     "py-trove-classifiers": {
-      "baseline": "2026.1.14.14",
+      "baseline": "2026.4.28.13",
       "port-version": 0
     },
     "py-typing-extensions": {

--- a/versions/p-/py-flit-core.json
+++ b/versions/p-/py-flit-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6cf9f6fce51f57c21f35e0d149ac104784301107",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "40b8415f737e449d3c41235397fd87b6c0e1533c",
       "version": "3.12.0",
       "port-version": 0

--- a/versions/p-/py-trove-classifiers.json
+++ b/versions/p-/py-trove-classifiers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "524c22af9c92d81c908d5c8d2565466890674231",
+      "version": "2026.4.28.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d192fa59c1e3efd894addf0caf55d67b38e18ed",
       "version": "2026.1.14.14",
       "port-version": 0


### PR DESCRIPTION
  Summary

✅ Updated (2):
  + py-trove-classifiers (2026.1.14.14 -> 2026.4.28.13)
  + py-flit-core (3.12.0 -> 4.0.0)

📦 Unchanged: 112