### PR TITLE
🚀 Auto-update ports 2026-05-05

### DIFF
--- a/ports/py-cryptography/portfile.cmake
+++ b/ports/py-cryptography/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    cryptography
     VERSION         ${VERSION}
-    SHA512          0d2fd9de7b6cfafef5f66e4fb10b7eaa8712bc0ed7bca19a017963b8ea707813a7bdc841f7d4aa512da7963eff3707792d46cb93058875fcc447961256c32d9e
+    SHA512          4d04983e25eb5fc856705f63e8cca32a357ef0a369c4596b1beb2e0befa2b3dcd763eb4e9baed4230bd75aa6738790ec56b107a45d5e02ce09f78fc1851c2ff9
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/py-cryptography/vcpkg.json
+++ b/ports/py-cryptography/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-cryptography",
-  "version": "47.0.0",
+  "version": "48.0.0",
   "description": "cryptography is a package which provides cryptographic recipes and primitives to Python developers",
   "homepage": "https://github.com/pyca/cryptography",
   "dependencies": [

--- a/ports/py-pip/portfile.cmake
+++ b/ports/py-pip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_pythonhosted(
     OUT_SOURCE_PATH SOURCE_PATH
     PACKAGE_NAME    pip
     VERSION         ${VERSION}
-    SHA512          9318ad22f97ffd54f1152052c83244d573a95648c3abcbc6bf01761e6785257726e0103bda600ded9338c308ac7de274fe93573da0bb5e590ced8da8847dc335
+    SHA512          e9419b7b2756c5ee43ec141c14f0d34349dea8b35c0ff5cbd7802fe090ef1340a4eada25f3007a71967544936245d035b05805001ace1a55b61f3e5fcb9afd0f
 )
 
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/py-pip/vcpkg.json
+++ b/ports/py-pip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "py-pip",
-  "version": "26.1",
+  "version": "26.1.1",
   "description": "Tool for installing and managing Python packages",
   "homepage": "https://pypi.org/project/setuptools",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,7 +89,7 @@
       "port-version": 0
     },
     "py-cryptography": {
-      "baseline": "47.0.0",
+      "baseline": "48.0.0",
       "port-version": 0
     },
     "py-cycler": {
@@ -261,7 +261,7 @@
       "port-version": 1
     },
     "py-pip": {
-      "baseline": "26.1",
+      "baseline": "26.1.1",
       "port-version": 0
     },
     "py-pip-system-certs": {

--- a/versions/p-/py-cryptography.json
+++ b/versions/p-/py-cryptography.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6532cc4e957cb49ed64ca191da675ef8bb827e9d",
+      "version": "48.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9b426e352a29e13cfa08fb830648bbda7fa0c703",
       "version": "47.0.0",
       "port-version": 0

--- a/versions/p-/py-pip.json
+++ b/versions/p-/py-pip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59b4857a260cec50f3650f96ae860a9b8e2de63d",
+      "version": "26.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "88fdd75da78cc5557501607b8e8ebd853e8c072c",
       "version": "26.1",
       "port-version": 0


### PR DESCRIPTION
  Summary

✅ Updated (2):
  + py-pip (26.1 -> 26.1.1)
  + py-cryptography (47.0.0 -> 48.0.0)

📦 Unchanged: 114