### PR TITLE
Fix psycopg

### DIFF
--- a/ports/py-psycopg-c/portfile.cmake
+++ b/ports/py-psycopg-c/portfile.cmake
@@ -7,9 +7,11 @@ vcpkg_from_pythonhosted(
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq") 
+  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq")
+  set(ENV{PG_CONFIG} "${CURRENT_INSTALLED_DIR}/tools/libpq/pg_config.exe")
 else()
-  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq/bin") 
+  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq/bin")
+  set(ENV{PG_CONFIG} "${CURRENT_INSTALLED_DIR}/tools/libpq/bin/pg_config")
 endif()
 
 set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")

--- a/ports/py-psycopg-c/vcpkg.json
+++ b/ports/py-psycopg-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-psycopg-c",
   "version": "3.3.4",
+  "port-version": 1,
   "description": "Python-PostgreSQL Database Adapter",
   "homepage": "https://psycopg.org/",
   "dependencies": [

--- a/versions/p-/py-psycopg-c.json
+++ b/versions/p-/py-psycopg-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1809f523dc3d477836dc2594b32c1674461030fb",
+      "version": "3.3.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "953a5b224639c110ad3d65aec40ab779600af130",
       "version": "3.3.4",
       "port-version": 0


### PR DESCRIPTION
when building QGIS:


```
2026-05-20 08:20:21,704 gpep517 INFO Building wheel via backend cython_backend
toml section missing PosixPath('pyproject.toml') does not contain a tool.setuptools_scm section
/Users/runner/work/QGIS/QGIS/build/vcpkg_installed/arm64-osx-dynamic-release/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py:72: _ExperimentalConfiguration: `[tool.setuptools.ext-modules]` in `pyproject.toml` is still *experimental* and likely to change in future releases.
  config = read_configuration(filepath, True, ignore_option_errors, dist)
2026-05-20 08:20:21,926 root INFO running bdist_wheel
2026-05-20 08:20:21,939 root INFO running build
2026-05-20 08:20:21,943 root INFO running build_py
2026-05-20 08:20:21,947 root INFO creating build/lib.macosx-15.7-arm64-cpython-312/psycopg_c
2026-05-20 08:20:21,947 root INFO copying psycopg_c/_uuid.py -> build/lib.macosx-15.7-arm64-cpython-312/psycopg_c
2026-05-20 08:20:21,948 root INFO copying psycopg_c/version.py -> build/lib.macosx-15.7-arm64-cpython-312/psycopg_c
2026-05-20 08:20:21,949 root INFO copying psycopg_c/__init__.py -> build/lib.macosx-15.7-arm64-cpython-312/psycopg_c
2026-05-20 08:20:21,949 root INFO running egg_info
2026-05-20 08:20:21,954 root INFO writing psycopg_c.egg-info/PKG-INFO
2026-05-20 08:20:21,954 root INFO writing dependency_links to psycopg_c.egg-info/dependency_links.txt
2026-05-20 08:20:21,955 root INFO writing top-level names to psycopg_c.egg-info/top_level.txt
2026-05-20 08:20:21,968 psycopg_build_ext ERROR couldn't run 'pg_config' --includedir: [Errno 2] No such file or directory: 'pg_config'
error: [Errno 2] No such file or directory: 'pg_config'
```
