### PR TITLE
[python3] Register port-version 2 in versions/

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -494,7 +494,7 @@
     },
     "python3": {
       "baseline": "3.12.11",
-      "port-version": 1
+      "port-version": 2
     },
     "swig": {
       "baseline": "4.2.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e579214e443fc91a8812b8c9691eb0691d7ac76a",
+      "version": "3.12.11",
+      "port-version": 2
+    },
+    {
       "git-tree": "aefc6a6874567010c388c9c9ef221cd6dc3c07a8",
       "version": "3.12.11",
       "port-version": 1


### PR DESCRIPTION
cbe3fc99 bumped ports/python3/vcpkg.json to port-version 2 
but never ran x-add-version, so versions still resolved python3 to port-version 1's tree (aefc6a6) which contains the unfixed portfile. vcpkg therefore kept building python3 with NAMES zlib only