### PR TITLE
[py-psycopg2] Make it usable without pg_config

### DIFF
--- a/ports/py-psycopg2/env_configurable.patch
+++ b/ports/py-psycopg2/env_configurable.patch
@@ -1,0 +1,41 @@
+--- a/setup.py
++++ b/setup.py
+@@ -79,8 +79,16 @@
+         self.build_ext = build_ext
+         self.pg_config_exe = self.build_ext.pg_config
+         if not self.pg_config_exe:
+-            self.pg_config_exe = self.autodetect_pg_config_path()
++            self.pg_config_exe = (
++                os.environ.get("PSYCOPG2_PG_CONFIG")
++                or self.autodetect_pg_config_path()
++            )
+         if self.pg_config_exe is None:
++            # If both directories are supplied via the environment, the
++            # missing pg_config is not fatal: query() will use them.
++            if (os.environ.get("PSYCOPG2_PG_INCLUDEDIR")
++                    and os.environ.get("PSYCOPG2_PG_LIBDIR")):
++                return
+             sys.stderr.write("""
+ Error: pg_config executable not found.
+ 
+@@ -104,6 +112,20 @@
+     def query(self, attr_name, *, empty_ok=False):
+         """Spawn the pg_config executable, querying for the given config
+         name, and return the printed value, sanitized. """
++        env_map = {
++            "includedir": "PSYCOPG2_PG_INCLUDEDIR",
++            "includedir-server": "PSYCOPG2_PG_INCLUDEDIR",
++            "libdir": "PSYCOPG2_PG_LIBDIR",
++        }
++        envvar = env_map.get(attr_name)
++        if envvar and os.environ.get(envvar):
++            return os.environ[envvar]
++        if self.pg_config_exe is None:
++            if empty_ok:
++                return ""
++            raise Warning(
++                f"pg_config --{attr_name}: set PSYCOPG2_PG_INCLUDEDIR/"
++                f"PSYCOPG2_PG_LIBDIR or make pg_config available")
+         try:
+             pg_config_process = subprocess.run(
+                 [self.pg_config_exe, "--" + attr_name],

--- a/ports/py-psycopg2/portfile.cmake
+++ b/ports/py-psycopg2/portfile.cmake
@@ -5,11 +5,44 @@ vcpkg_from_pythonhosted(
     SHA512          0d37b51408298baad8b2b095af24b1c0d0b67ba99a2532ed7344a931c6f4d431be9c21c94811eace1b4418899f070f80e80266bfe0386aac2e64289ab1b8862e
 )
 
+# psycopg2's setup.py invokes `pg_config` by literal name and ignores the
+# PG_CONFIG environment variable, so we must expose a working `pg_config`
+# on PATH that returns vcpkg-relative paths.
+#
+# Since libpq switched to meson (microsoft/vcpkg#51250), `pg_config` is no
+# longer placed in the standard `bin/` directory but under
+# `tools/libpq/pg_config`, and on some platforms the binary itself may not
+# be directly usable from outside its install tree. Instead of relying on
+# it, drop a tiny stub on PATH that answers the only two queries psycopg2
+# actually needs (`--includedir` and `--libdir`) using CURRENT_INSTALLED_DIR.
+# Mirrors the stub used by py-psycopg-c.
+set(PG_CONFIG_STUB_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-pg-config-stub")
+file(REMOVE_RECURSE "${PG_CONFIG_STUB_DIR}")
+file(MAKE_DIRECTORY "${PG_CONFIG_STUB_DIR}")
+
 if(VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq") 
+    set(PG_CONFIG_STUB "${PG_CONFIG_STUB_DIR}/pg_config.bat")
+    file(WRITE "${PG_CONFIG_STUB}"
+"@echo off\r\n\
+if /I \"%~1\"==\"--includedir\" ( echo ${CURRENT_INSTALLED_DIR}/include & exit /b 0 )\r\n\
+if /I \"%~1\"==\"--libdir\" ( echo ${CURRENT_INSTALLED_DIR}/lib & exit /b 0 )\r\n\
+\"${CURRENT_INSTALLED_DIR}/tools/libpq/pg_config.exe\" %*\r\n"
+    )
 else()
-  vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/libpq/bin") 
+    set(PG_CONFIG_STUB "${PG_CONFIG_STUB_DIR}/pg_config")
+    file(WRITE "${PG_CONFIG_STUB}"
+"#!/bin/sh
+case \"$1\" in
+    --includedir) echo \"${CURRENT_INSTALLED_DIR}/include\" ;;
+    --libdir)     echo \"${CURRENT_INSTALLED_DIR}/lib\" ;;
+    *)            exec \"${CURRENT_INSTALLED_DIR}/tools/libpq/pg_config\" \"$@\" ;;
+esac
+"
+    )
+    execute_process(COMMAND chmod +x "${PG_CONFIG_STUB}")
 endif()
+
+vcpkg_add_to_path(PREPEND "${PG_CONFIG_STUB_DIR}")
 
 set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
 

--- a/ports/py-psycopg2/portfile.cmake
+++ b/ports/py-psycopg2/portfile.cmake
@@ -3,46 +3,17 @@ vcpkg_from_pythonhosted(
     PACKAGE_NAME    psycopg2
     VERSION         ${VERSION}
     SHA512          0d37b51408298baad8b2b095af24b1c0d0b67ba99a2532ed7344a931c6f4d431be9c21c94811eace1b4418899f070f80e80266bfe0386aac2e64289ab1b8862e
+    PATCHES
+      env_configurable.patch
 )
 
-# psycopg2's setup.py invokes `pg_config` by literal name and ignores the
-# PG_CONFIG environment variable, so we must expose a working `pg_config`
-# on PATH that returns vcpkg-relative paths.
-#
-# Since libpq switched to meson (microsoft/vcpkg#51250), `pg_config` is no
-# longer placed in the standard `bin/` directory but under
-# `tools/libpq/pg_config`, and on some platforms the binary itself may not
-# be directly usable from outside its install tree. Instead of relying on
-# it, drop a tiny stub on PATH that answers the only two queries psycopg2
-# actually needs (`--includedir` and `--libdir`) using CURRENT_INSTALLED_DIR.
-# Mirrors the stub used by py-psycopg-c.
-set(PG_CONFIG_STUB_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-pg-config-stub")
-file(REMOVE_RECURSE "${PG_CONFIG_STUB_DIR}")
-file(MAKE_DIRECTORY "${PG_CONFIG_STUB_DIR}")
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    set(PG_CONFIG_STUB "${PG_CONFIG_STUB_DIR}/pg_config.bat")
-    file(WRITE "${PG_CONFIG_STUB}"
-"@echo off\r\n\
-if /I \"%~1\"==\"--includedir\" ( echo ${CURRENT_INSTALLED_DIR}/include & exit /b 0 )\r\n\
-if /I \"%~1\"==\"--libdir\" ( echo ${CURRENT_INSTALLED_DIR}/lib & exit /b 0 )\r\n\
-\"${CURRENT_INSTALLED_DIR}/tools/libpq/pg_config.exe\" %*\r\n"
-    )
-else()
-    set(PG_CONFIG_STUB "${PG_CONFIG_STUB_DIR}/pg_config")
-    file(WRITE "${PG_CONFIG_STUB}"
-"#!/bin/sh
-case \"$1\" in
-    --includedir) echo \"${CURRENT_INSTALLED_DIR}/include\" ;;
-    --libdir)     echo \"${CURRENT_INSTALLED_DIR}/lib\" ;;
-    *)            exec \"${CURRENT_INSTALLED_DIR}/tools/libpq/pg_config\" \"$@\" ;;
-esac
-"
-    )
-    execute_process(COMMAND chmod +x "${PG_CONFIG_STUB}")
-endif()
-
-vcpkg_add_to_path(PREPEND "${PG_CONFIG_STUB_DIR}")
+# Teach psycopg2's setup.py to read the libpq include/lib directories
+# from environment variables instead of shelling out to `pg_config`.
+# Mirrors the approach used by py-psycopg-c (see commit 1578c39e). This
+# avoids depending on `tools/libpq/pg_config`, which may be absent on
+# dynamic triplets where libpq is built via meson.
+set(ENV{PSYCOPG2_PG_INCLUDEDIR} "${CURRENT_INSTALLED_DIR}/include")
+set(ENV{PSYCOPG2_PG_LIBDIR} "${CURRENT_INSTALLED_DIR}/lib")
 
 set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
 

--- a/ports/py-psycopg2/vcpkg.json
+++ b/ports/py-psycopg2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-psycopg2",
   "version": "2.9.12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Python-PostgreSQL Database Adapter",
   "homepage": "https://psycopg.org/",
   "dependencies": [

--- a/ports/py-psycopg2/vcpkg.json
+++ b/ports/py-psycopg2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-psycopg2",
   "version": "2.9.12",
+  "port-version": 1,
   "description": "Python-PostgreSQL Database Adapter",
   "homepage": "https://psycopg.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -298,7 +298,7 @@
     },
     "py-psycopg2": {
       "baseline": "2.9.12",
-      "port-version": 0
+      "port-version": 1
     },
     "py-pycodestyle": {
       "baseline": "2.14.0",

--- a/versions/p-/py-psycopg2.json
+++ b/versions/p-/py-psycopg2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14c0fc870daad433a2b0932cb0fa67324bea7e65",
+      "version": "2.9.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "e1c06e04e7bb64702216984b5008a89e056e92ce",
       "version": "2.9.12",
       "port-version": 0


### PR DESCRIPTION
Mirrors the stub-based approach from py-psycopg-c (PR #240): drop a tiny pg_config shim on PATH that returns vcpkg-relative paths for --includedir / --libdir. Fixes 'pg_config executable not found' on macOS arm after microsoft/vcpkg#51250 moved pg_config from tools/libpq/bin/ to tools/libpq/.