### PR TITLE
[py-psycopg2] Re-register version 2.9.12#2

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -298,7 +298,7 @@
     },
     "py-psycopg2": {
       "baseline": "2.9.12",
-      "port-version": 1
+      "port-version": 2
     },
     "py-pycodestyle": {
       "baseline": "2.14.0",

--- a/versions/p-/py-psycopg2.json
+++ b/versions/p-/py-psycopg2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8b56518a853d929e697693035c315791f8ca2b9",
+      "version": "2.9.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "14c0fc870daad433a2b0932cb0fa67324bea7e65",
       "version": "2.9.12",
       "port-version": 1


### PR DESCRIPTION
PR #242 was merged with port-version bumped to 2 and an env_configurable.patch replacing the stub-on-PATH approach, but versions/p-/py-psycopg2.json was never updated. baseline.json pointed to a non-existent git-tree for #1, breaking 'vcpkg install' resolution: 'failed to unpack tree object 14c0fc870daad433a2b0932cb0fa67324bea7e65'. Register the current port-version 2 with the correct tree.