### PR TITLE
[py-threadpoolctl] Install upstream wheel (flit_core 4 compat)

### DIFF
--- a/ports/py-threadpoolctl/portfile.cmake
+++ b/ports/py-threadpoolctl/portfile.cmake
@@ -1,14 +1,20 @@
-vcpkg_from_pythonhosted(
-    OUT_SOURCE_PATH SOURCE_PATH
-    PACKAGE_NAME    threadpoolctl
-    VERSION         ${VERSION}
-    SHA512          1fcc39a643db15b7415ad81206078d5ec571d99bab2a8b6c63180f45ce43479876700e3eb36a317b51df18633b2c5455d54553dd710a9c9a8ce2f77bebd5792a
-    FILENAME        threadpoolctl
+# threadpoolctl 3.6.0 is the last release and still uses the legacy
+# [tool.flit.metadata] pyproject table, which flit_core 4 rejects with:
+#   ConfigError: The [tool.flit.metadata] table is no longer supported.
+# Upstream has not yet released a version migrated to [project]
+# (see https://github.com/joblib/threadpoolctl).
+# Since threadpoolctl is pure Python and upstream already publishes a
+# py3-none-any wheel built with the older flit_core, install that wheel
+# directly instead of rebuilding from the sdist.
+vcpkg_download_distfile(wheel
+    URLS "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-${VERSION}-py3-none-any.whl"
+    FILENAME "threadpoolctl-${VERSION}-py3-none-any.whl"
+    SHA512 07e94fb472e7a3710e7dd331ba6ff9b827f6eeccb13bd25922ed832f5ee454ad86c4edfc61a1587525ea976f33bdac20773a5b42c8c160ade2ffb7c409c19783
 )
 
-vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_python_install_wheel(WHEEL "${wheel}")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PACKAGES_DIR}/${PYTHON3_SITE}/threadpoolctl-${VERSION}.dist-info/licenses/LICENSE")
 vcpkg_python_test_import(MODULE "threadpoolctl")
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/py-threadpoolctl/vcpkg.json
+++ b/ports/py-threadpoolctl/vcpkg.json
@@ -1,18 +1,11 @@
 {
   "name": "py-threadpoolctl",
   "version": "3.6.0",
+  "port-version": 1,
   "description": "Python helpers to limit the number of threads used in the threadpool-backed of common native libraries.",
   "homepage": "https://github.com/joblib/threadpoolctl",
   "license": "BSD-3-Clause",
   "dependencies": [
-    {
-      "name": "py-cython",
-      "host": true
-    },
-    {
-      "name": "py-setuptools",
-      "host": true
-    },
     "python3",
     {
       "name": "vcpkg-python-scripts",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -442,7 +442,7 @@
     },
     "py-threadpoolctl": {
       "baseline": "3.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-tomli": {
       "baseline": "2.0.1",

--- a/versions/p-/py-threadpoolctl.json
+++ b/versions/p-/py-threadpoolctl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0a6718bab8a72b9a49b0ee4846f3c203f59b26a",
+      "version": "3.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "546afcb60832d848b98d5f3ad719a0832c33b0fb",
       "version": "3.6.0",
       "port-version": 0


### PR DESCRIPTION
threadpoolctl 3.6.0 (the latest release) still uses the legacy [tool.flit.metadata] pyproject table, which py-flit-core 4 now rejects with: 'The [tool.flit.metadata] table is no longer supported. Switch to the standard [project] table or require flit_core<4 to build this package.' Upstream has not released a migrated version yet.

Since threadpoolctl is pure Python and upstream already publishes a py3-none-any wheel built with the older flit_core, download and install that wheel directly instead of rebuilding from the sdist. This sidesteps the build-backend incompatibility entirely. Drop the now-unused py-cython and py-setuptools host dependencies and bump port-version to 1.