### PR TITLE
Prevent clash with system GDAL

### DIFF
--- a/ports/py-rasterio/no-gdal-config-autodetect.patch
+++ b/ports/py-rasterio/no-gdal-config-autodetect.patch
@@ -1,0 +1,27 @@
+--- a/setup.py
++++ b/setup.py
+@@ -233,24 +233,6 @@
+         log.info("GDAL API version obtained from gdal-config: %s", gdalversion)
+
+ if "clean" not in sys.argv:
+-    try:
+-        fill_gdal_build_options_using_gdal_config()
+-    except Exception as e:
+-        # Try to run gdalinfo and get information from that instead
+-        log.info(
+-            "Failed to use gdal-config, trying to run gdalinfo instead (gdal-config error of type %s: %s)",
+-            type(e).__name__,
+-            e,
+-        )
+-        try:
+-            fill_gdal_build_options_using_executable(executable_name="gdalinfo")
+-        except Exception as e:
+-            log.warning(
+-                "Failed to get options via both gdal-config and gdalinfo. (gdalinfo error of type %s: %s)",
+-                type(e).__name__,
+-                e,
+-            )
+-
+     # Get GDAL API version from environment variable.
+     if 'GDAL_VERSION' in os.environ:
+         gdalversion = os.environ['GDAL_VERSION']

--- a/ports/py-rasterio/no-gdal-config-autodetect.patch
+++ b/ports/py-rasterio/no-gdal-config-autodetect.patch
@@ -2,7 +2,7 @@
 +++ b/setup.py
 @@ -233,24 +233,6 @@
          log.info("GDAL API version obtained from gdal-config: %s", gdalversion)
-
+ 
  if "clean" not in sys.argv:
 -    try:
 -        fill_gdal_build_options_using_gdal_config()

--- a/ports/py-rasterio/portfile.cmake
+++ b/ports/py-rasterio/portfile.cmake
@@ -34,6 +34,10 @@ library_dirs=${CURRENT_INSTALLED_DIR}/lib
 libraries=gdal
 ")
 
+vcpkg_apply_patches(SOURCE_PATH "${SOURCE_PATH}"
+    PATCHES no-gdal-config-autodetect.patch
+)
+
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/py-rasterio/portfile.cmake
+++ b/ports/py-rasterio/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_pythonhosted(
     VERSION         ${VERSION}
     SHA512          ce20ca32ea3e4a887dd2fc18ccae4abe774d3754bc560b8a85228d9df58a829e12a04c2dcca2aadbcf888afd6dd89fe5a66cb0ec8231c9d996002ca47742e053
     FILENAME        rasterio
+    PATCHES
+        no-gdal-config-autodetect.patch
 )
 # Read GDAL version from SPDX metadata
 set(GDAL_SPDX "${CURRENT_INSTALLED_DIR}/share/gdal/vcpkg.spdx.json")
@@ -33,10 +35,6 @@ include_dirs=${CURRENT_INSTALLED_DIR}/include
 library_dirs=${CURRENT_INSTALLED_DIR}/lib
 libraries=gdal
 ")
-
-vcpkg_apply_patches(SOURCE_PATH "${SOURCE_PATH}"
-    PATCHES no-gdal-config-autodetect.patch
-)
 
 vcpkg_python_build_and_install_wheel(SOURCE_PATH "${SOURCE_PATH}")
 

--- a/ports/py-rasterio/vcpkg.json
+++ b/ports/py-rasterio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-rasterio",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "Fast and direct raster I/O for use with Numpy and SciPy.",
   "homepage": "https://rasterio.readthedocs.io/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -374,7 +374,7 @@
     },
     "py-rasterio": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-referencing": {
       "baseline": "0.37.0",

--- a/versions/p-/py-rasterio.json
+++ b/versions/p-/py-rasterio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "021d3dd3a2f4d57f6c4cacdfce133c11493fa10e",
+      "git-tree": "d166c0f95f16623714a66c78fb12e2720bba8422",
       "version": "1.5.0",
       "port-version": 1
     },

--- a/versions/p-/py-rasterio.json
+++ b/versions/p-/py-rasterio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "021d3dd3a2f4d57f6c4cacdfce133c11493fa10e",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dee14f27261433e01b6e3dd0ca010cc870e3bc5b",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
On macOS, I have GDAL 3.13.0 from Homebrew and rasterio's setup.py was mistakenly using it instead of using GDAL from vcpkg port. The problem is that GDAL vcpkg port deletes gdal-config (for whatever reason) and so the gdal-config from PATH (Homebrew) gets picked and rasterio uses headers/libs from here. Then, when loaded against GDAL from vcpkg (3.12.x) I was getting a nasty ImportError due to ABI mismatch.

The fix makes sure that rasterio ignores gdal-config, because there is no such executable from GDAL vcpkg port anyway.

This surfaced for me with the recent vcpkg bump in QGIS...