### PR TITLE
mark vcpkg-python-scripts as a host dependency consistently

### DIFF
--- a/ports/py-annotated-types/vcpkg.json
+++ b/ports/py-annotated-types/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-annotated-types",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Reusable constraints for Python types, using PEP 593 Annotated",
   "homepage": "https://github.com/pydantic/annotated-types",
   "license": null,
@@ -13,6 +14,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-certifi/vcpkg.json
+++ b/ports/py-certifi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-certifi",
   "version-date": "2026-06-17",
+  "port-version": 1,
   "description": "A carefully curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts.",
   "homepage": "https://github.com/certifi/python-certifi",
   "license": null,
@@ -10,6 +11,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-cppy/vcpkg.json
+++ b/ports/py-cppy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-cppy",
   "version": "1.2.1",
+  "port-version": 1,
   "description": "A collection of C++ headers which make it easier to write Python C extension modules",
   "homepage": "https://cppy.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-cycler/vcpkg.json
+++ b/ports/py-cycler/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-cycler",
   "version": "0.12.1",
+  "port-version": 1,
   "description": "cycler: composable cycles",
   "homepage": "https://matplotlib.org/cycler/",
   "license": "BSD-3-Clause",
@@ -10,6 +11,9 @@
       "host": true
     },
     "python3",
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-dateutil/vcpkg.json
+++ b/ports/py-dateutil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-dateutil",
   "version": "2.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Useful extensions to the standard Python datetime features",
   "homepage": "https://github.com/dateutil/dateutil",
   "license": null,
@@ -11,6 +11,9 @@
       "host": true
     },
     "py-six",
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-hatch-fancy-pypi-readme/vcpkg.json
+++ b/ports/py-hatch-fancy-pypi-readme/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-hatch-fancy-pypi-readme",
   "version": "25.1.0",
+  "port-version": 1,
   "description": "Fancy PyPI READMEs with Hatch",
   "homepage": "https://github.com/hynek/hatch-fancy-pypi-readme",
   "dependencies": [
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-kiwisolver/vcpkg.json
+++ b/ports/py-kiwisolver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-kiwisolver",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "Efficient C++ implementation of the Cassowary constraint solving algorithm",
   "homepage": "https://kiwisolver.readthedocs.io/en/latest/",
   "license": null,
@@ -10,6 +11,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-matplotlib/vcpkg.json
+++ b/ports/py-matplotlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-matplotlib",
   "version": "3.11.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Matplotlib is a comprehensive library for creating static, animated, and interactive visualizations in Python.",
   "homepage": "https://matplotlib.org/stable/",
   "license": null,
@@ -34,7 +34,10 @@
       ]
     },
     "qhull",
-    "vcpkg-python-scripts",
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/ports/py-meson/vcpkg.json
+++ b/ports/py-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-meson",
   "version": "0.20.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Meson PEP 517 Python build backend",
   "homepage": "https://github.com/mesonbuild/meson-python",
   "license": "MIT",
@@ -21,7 +21,10 @@
         "extensions"
       ]
     },
-    "vcpkg-python-scripts",
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/ports/py-packaging/vcpkg.json
+++ b/ports/py-packaging/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "py-packaging",
   "version": "26.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Core utilities for Python packages",
   "homepage": "https://packaging.pypa.io/",
   "license": "MIT",
   "dependencies": [
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-pillow/vcpkg.json
+++ b/ports/py-pillow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-pillow",
   "version": "12.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Python Imaging Library",
   "homepage": "https://python-pillow.org/",
   "license": null,
@@ -30,7 +30,10 @@
       "host": true
     },
     "tiff",
-    "vcpkg-python-scripts",
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/ports/py-pyproject-metadata/vcpkg.json
+++ b/ports/py-pyproject-metadata/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-pyproject-metadata",
   "version": "0.11.0",
+  "port-version": 1,
   "description": "PEP 621 metadata parsing",
   "homepage": "https://pep621.readthedocs.io/",
   "license": "MIT",
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-scikit-build-core/vcpkg.json
+++ b/ports/py-scikit-build-core/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-scikit-build-core",
   "version": "0.12.2",
+  "port-version": 1,
   "description": "A next generation Python CMake adaptor and Python API for plugins",
   "homepage": "https://scikit-build-core.readthedocs.io/",
   "license": "Apache-2.0",
@@ -21,6 +22,9 @@
       "name": "py-setuptools-scm",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-scikit-build/vcpkg.json
+++ b/ports/py-scikit-build/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-scikit-build",
   "version": "0.19.1",
+  "port-version": 1,
   "description": "Improved build system generator for Python C/C++/Fortran/Cython extensions",
   "homepage": "https://github.com/scikit-build/scikit-build",
   "dependencies": [
@@ -20,6 +21,9 @@
       "name": "py-setuptools-scm",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-scikit-build/vcpkg.json
+++ b/ports/py-scikit-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-scikit-build",
   "version": "0.19.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Improved build system generator for Python C/C++/Fortran/Cython extensions",
   "homepage": "https://github.com/scikit-build/scikit-build",
   "dependencies": [
@@ -13,6 +13,7 @@
       "name": "py-hatch-vcs",
       "host": true
     },
+    "py-packaging",
     "py-setuptools",
     {
       "name": "py-setuptools",
@@ -22,6 +23,7 @@
       "name": "py-setuptools-scm",
       "host": true
     },
+    "py-wheel",
     {
       "name": "vcpkg-python-scripts",
       "host": true

--- a/ports/py-scikit-build/vcpkg.json
+++ b/ports/py-scikit-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-scikit-build",
   "version": "0.19.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Improved build system generator for Python C/C++/Fortran/Cython extensions",
   "homepage": "https://github.com/scikit-build/scikit-build",
   "dependencies": [
@@ -13,6 +13,7 @@
       "name": "py-hatch-vcs",
       "host": true
     },
+    "py-setuptools",
     {
       "name": "py-setuptools",
       "host": true

--- a/ports/py-semantic-version/vcpkg.json
+++ b/ports/py-semantic-version/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-semantic-version",
   "version": "2.10.0",
+  "port-version": 1,
   "description": "About Semantic version comparison for Python (see http://semver.org/)",
   "homepage": "https://python-markdown.github.io/",
   "license": "BSD-2-Clause",
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-setuptools-scm/vcpkg.json
+++ b/ports/py-setuptools-scm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-setuptools-scm",
   "version": "9.2.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "the blessed package to manage your versions by scm tags",
   "homepage": "https://github.com/pypa/setuptools_scm",
   "license": "MIT",
@@ -14,13 +14,17 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-get-python-packages",
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
     {
       "name": "vcpkg-python-scripts",
       "host": true
     },
     {
       "name": "vcpkg-tool-mercurial",
+      "host": true,
       "platform": "windows"
     }
   ]

--- a/ports/py-setuptools-scm/vcpkg.json
+++ b/ports/py-setuptools-scm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "py-setuptools-scm",
   "version": "9.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "the blessed package to manage your versions by scm tags",
   "homepage": "https://github.com/pypa/setuptools_scm",
   "license": "MIT",
@@ -15,7 +15,10 @@
       "host": true
     },
     "vcpkg-get-python-packages",
-    "vcpkg-python-scripts",
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-mercurial",
       "platform": "windows"

--- a/ports/py-six/vcpkg.json
+++ b/ports/py-six/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-six",
   "version": "1.17.0",
+  "port-version": 1,
   "description": "Python 2 and 3 compatibility library ",
   "homepage": "https://github.com/benjaminp/six",
   "license": null,
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-tomli/vcpkg.json
+++ b/ports/py-tomli/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "py-tomli",
   "version": "2.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A simple, correct Python build frontend ",
   "homepage": "https://github.com/hukkin/tomli",
   "license": "MIT",
   "dependencies": [
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-typing-extensions/vcpkg.json
+++ b/ports/py-typing-extensions/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-typing-extensions",
   "version": "4.15.0",
+  "port-version": 1,
   "description": "Backported and experimental type hints for Python",
   "homepage": "https://github.com/python/typing_extensions",
   "license": null,
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-typing-inspection/vcpkg.json
+++ b/ports/py-typing-inspection/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "py-typing-inspection",
   "version": "0.4.2",
+  "port-version": 1,
   "description": "Runtime typing introspection tools",
   "homepage": "https://github.com/pydantic/typing-inspection",
   "license": null,
@@ -9,6 +10,9 @@
       "name": "py-setuptools",
       "host": true
     },
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/py-wheel/vcpkg.json
+++ b/ports/py-wheel/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "py-wheel",
   "version": "0.47.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The official binary distribution format for Python",
   "homepage": "https://github.com/pypa/wheel",
   "license": "MIT",
   "dependencies": [
-    "vcpkg-python-scripts"
+    {
+      "name": "vcpkg-python-scripts",
+      "host": true
+    }
   ]
 }

--- a/ports/vcpkg-tool-mercurial/vcpkg.json
+++ b/ports/vcpkg-tool-mercurial/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-tool-mercurial",
   "version-date": "2023-06-27",
+  "port-version": 1,
   "description": "Mercurial SCM",
   "homepage": "https://www.mercurial-scm.org/",
   "license": "MIT",
@@ -8,6 +9,7 @@
   "dependencies": [
     {
       "name": "vcpkg-tool-lessmsi",
+      "host": true,
       "platform": "windows"
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "py-annotated-types": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-attrs": {
       "baseline": "26.1.0",
@@ -66,7 +66,7 @@
     },
     "py-certifi": {
       "baseline": "2026-06-17",
-      "port-version": 0
+      "port-version": 1
     },
     "py-cffi": {
       "baseline": "2.0.0",
@@ -86,7 +86,7 @@
     },
     "py-cppy": {
       "baseline": "1.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "py-cryptography": {
       "baseline": "49.0.0",
@@ -94,7 +94,7 @@
     },
     "py-cycler": {
       "baseline": "0.12.1",
-      "port-version": 0
+      "port-version": 1
     },
     "py-cython": {
       "baseline": "3.2.5",
@@ -102,7 +102,7 @@
     },
     "py-dateutil": {
       "baseline": "2.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "py-duckdb": {
       "baseline": "1.5.4",
@@ -146,7 +146,7 @@
     },
     "py-hatch-fancy-pypi-readme": {
       "baseline": "25.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-hatch-vcs": {
       "baseline": "0.5.0",
@@ -194,7 +194,7 @@
     },
     "py-kiwisolver": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-lazy-loader": {
       "baseline": "0.5",
@@ -214,7 +214,7 @@
     },
     "py-matplotlib": {
       "baseline": "3.11.0",
-      "port-version": 7
+      "port-version": 8
     },
     "py-maturin": {
       "baseline": "1.14.1",
@@ -222,7 +222,7 @@
     },
     "py-meson": {
       "baseline": "0.20.0",
-      "port-version": 1
+      "port-version": 2
     },
     "py-narwhals": {
       "baseline": "2.22.1",
@@ -246,7 +246,7 @@
     },
     "py-packaging": {
       "baseline": "26.2",
-      "port-version": 1
+      "port-version": 2
     },
     "py-pandas": {
       "baseline": "3.0.3",
@@ -258,7 +258,7 @@
     },
     "py-pillow": {
       "baseline": "12.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "py-pip": {
       "baseline": "26.1.2",
@@ -334,7 +334,7 @@
     },
     "py-pyproject-metadata": {
       "baseline": "0.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-pyqt-builder": {
       "baseline": "1.19.1",
@@ -394,11 +394,11 @@
     },
     "py-scikit-build": {
       "baseline": "0.19.1",
-      "port-version": 0
+      "port-version": 1
     },
     "py-scikit-build-core": {
       "baseline": "0.12.2",
-      "port-version": 0
+      "port-version": 1
     },
     "py-scikit-learn": {
       "baseline": "1.9.0",
@@ -410,7 +410,7 @@
     },
     "py-semantic-version": {
       "baseline": "2.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-setuptools": {
       "baseline": "82.0.1",
@@ -422,7 +422,7 @@
     },
     "py-setuptools-scm": {
       "baseline": "9.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "py-shapely": {
       "baseline": "2.1.2",
@@ -434,7 +434,7 @@
     },
     "py-six": {
       "baseline": "1.17.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-sspilib": {
       "baseline": "0.5.0",
@@ -446,7 +446,7 @@
     },
     "py-tomli": {
       "baseline": "2.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "py-trove-classifiers": {
       "baseline": "2026.6.1.19",
@@ -454,11 +454,11 @@
     },
     "py-typing-extensions": {
       "baseline": "4.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "py-typing-inspection": {
       "baseline": "0.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "py-tzdata": {
       "baseline": "2026.2",
@@ -482,7 +482,7 @@
     },
     "py-wheel": {
       "baseline": "0.47.0",
-      "port-version": 1
+      "port-version": 2
     },
     "py-wrapt": {
       "baseline": "2.2.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -394,7 +394,7 @@
     },
     "py-scikit-build": {
       "baseline": "0.19.1",
-      "port-version": 2
+      "port-version": 3
     },
     "py-scikit-build-core": {
       "baseline": "0.12.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -422,7 +422,7 @@
     },
     "py-setuptools-scm": {
       "baseline": "9.2.2",
-      "port-version": 2
+      "port-version": 3
     },
     "py-shapely": {
       "baseline": "2.1.2",
@@ -506,7 +506,7 @@
     },
     "vcpkg-tool-mercurial": {
       "baseline": "2023-06-27",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-tool-rust": {
       "baseline": "2025-03-13",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -394,7 +394,7 @@
     },
     "py-scikit-build": {
       "baseline": "0.19.1",
-      "port-version": 1
+      "port-version": 2
     },
     "py-scikit-build-core": {
       "baseline": "0.12.2",

--- a/versions/p-/py-annotated-types.json
+++ b/versions/p-/py-annotated-types.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa30669bf46b806e28782f16bd55fe7b5859d260",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ae60fc3ee9b15a8aac198e88e5a29a6613fbada1",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/p-/py-certifi.json
+++ b/versions/p-/py-certifi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31f960a6a93830e2874f71fd25a2e8453723e2d9",
+      "version-date": "2026-06-17",
+      "port-version": 1
+    },
+    {
       "git-tree": "68f29e5b4841cd3bebc609a27aedc0a1e46e3c7a",
       "version-date": "2026-06-17",
       "port-version": 0

--- a/versions/p-/py-cppy.json
+++ b/versions/p-/py-cppy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5473fc8b110dda2bb0acc0a845c7d90331d9b67e",
+      "version": "1.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "53aa01248bb3b8ba945ea320b32e525d3872f2dd",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/p-/py-cycler.json
+++ b/versions/p-/py-cycler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2703d4588e54dafeb268b207c7d80a89bce8be9f",
+      "version": "0.12.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "91e75195c4108f7a876fed0bcd4dfd48c897427d",
       "version": "0.12.1",
       "port-version": 0

--- a/versions/p-/py-dateutil.json
+++ b/versions/p-/py-dateutil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4eaa9eb0ff557b1ffcbb3545d5d8867fea4cbe5f",
+      "version": "2.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "491d9148b2def0f2efb1036bda95afe09d282952",
       "version": "2.9.0",
       "port-version": 1

--- a/versions/p-/py-hatch-fancy-pypi-readme.json
+++ b/versions/p-/py-hatch-fancy-pypi-readme.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a870fe06a716a75e0352411b8f393acfdf5ead74",
+      "version": "25.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5ead7ea8860cb8282787631ab46fa510fb56b629",
       "version": "25.1.0",
       "port-version": 0

--- a/versions/p-/py-kiwisolver.json
+++ b/versions/p-/py-kiwisolver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1743849ccf4c24b697286d5e8879cb0b2eb4933",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "98433f2be008e74e2569696ce03198b4254e14b1",
       "version": "1.5.0",
       "port-version": 0

--- a/versions/p-/py-matplotlib.json
+++ b/versions/p-/py-matplotlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23ec686eae4a2ba0a428053e2a33b96bd65dcbcc",
+      "version": "3.11.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "80552efe6030b04344cd9826a76f3b290425658b",
       "version": "3.11.0",
       "port-version": 7

--- a/versions/p-/py-meson.json
+++ b/versions/p-/py-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0168ddb44137b814825aa0a741b607dee8af0159",
+      "version": "0.20.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "548eed2231c165b9e86e101e39c1e6ebb6439dda",
       "version": "0.20.0",
       "port-version": 1

--- a/versions/p-/py-packaging.json
+++ b/versions/p-/py-packaging.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8844c2fcb1b281b3a311a2b12fa1c3dee96864f9",
+      "version": "26.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "a7d311a2f5572d99b791514c1381401fe62d9aad",
       "version": "26.2",
       "port-version": 1

--- a/versions/p-/py-pillow.json
+++ b/versions/p-/py-pillow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "446fad1a3e3bad008e5627901a12c69288dfc2bf",
+      "version": "12.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5b3129d0578150c2601f4ca23f50229ab0cc91f2",
       "version": "12.2.0",
       "port-version": 1

--- a/versions/p-/py-pyproject-metadata.json
+++ b/versions/p-/py-pyproject-metadata.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fe845d5b2370d65c6724346ce943cc174c10c23",
+      "version": "0.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d2d0baf4cce8629fb83a5ae994d0920d83c3b950",
       "version": "0.11.0",
       "port-version": 0

--- a/versions/p-/py-scikit-build-core.json
+++ b/versions/p-/py-scikit-build-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fe9c0d06ced0db237c7f0a0830da932a6d69558",
+      "version": "0.12.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bec7e13e5e35382b0bdd4ff388855f7eb8ea2222",
       "version": "0.12.2",
       "port-version": 0

--- a/versions/p-/py-scikit-build.json
+++ b/versions/p-/py-scikit-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "052a67ed2c3b67d8556138fadc3ba7053fd102d4",
+      "version": "0.19.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a2ec42f0c697da666e0d1819b2d1f69919c5f4ed",
       "version": "0.19.1",
       "port-version": 0

--- a/versions/p-/py-scikit-build.json
+++ b/versions/p-/py-scikit-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1502283308759d1b8e69285567356eefff5c0b4c",
+      "version": "0.19.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "052a67ed2c3b67d8556138fadc3ba7053fd102d4",
       "version": "0.19.1",
       "port-version": 1

--- a/versions/p-/py-scikit-build.json
+++ b/versions/p-/py-scikit-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ca13be9a6c62cedf45812dfd2f61a23b115baff",
+      "version": "0.19.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "1502283308759d1b8e69285567356eefff5c0b4c",
       "version": "0.19.1",
       "port-version": 2

--- a/versions/p-/py-semantic-version.json
+++ b/versions/p-/py-semantic-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63e2abbb942ce09f2285c49e1fbacf1ab624fb37",
+      "version": "2.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "897dd1e85d2d4bca32205cc5fde7b1dc8faf545f",
       "version": "2.10.0",
       "port-version": 0

--- a/versions/p-/py-setuptools-scm.json
+++ b/versions/p-/py-setuptools-scm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d176dac22a08968c860d04c6e9b6e6e6abedd989",
+      "version": "9.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "606a5773466e62828f619dfddd11be8e030d8923",
       "version": "9.2.2",
       "port-version": 1

--- a/versions/p-/py-setuptools-scm.json
+++ b/versions/p-/py-setuptools-scm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fcc86bafeaa2f00f7d805f4e68df150422e6eb93",
+      "version": "9.2.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "d176dac22a08968c860d04c6e9b6e6e6abedd989",
       "version": "9.2.2",
       "port-version": 2

--- a/versions/p-/py-six.json
+++ b/versions/p-/py-six.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae13104ecd517cc062b224ff0e666396d4b2837b",
+      "version": "1.17.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f65786954fbadc8a4ef573dc52b5a2bb83806499",
       "version": "1.17.0",
       "port-version": 0

--- a/versions/p-/py-tomli.json
+++ b/versions/p-/py-tomli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6b530fe8ba99dca0208a9089ab98788b18b3abe",
+      "version": "2.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "817e633f5a9e37e90e5e9ddfed25add764a0fdfa",
       "version": "2.0.1",
       "port-version": 1

--- a/versions/p-/py-typing-extensions.json
+++ b/versions/p-/py-typing-extensions.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b0623ef78533d83d398a8ed70ec0f9486367adc",
+      "version": "4.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dff70c979468c6c4bcb9275ae4862981dc6d9208",
       "version": "4.15.0",
       "port-version": 0

--- a/versions/p-/py-typing-inspection.json
+++ b/versions/p-/py-typing-inspection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7e8b4b4403391af14f63f4ebc7a67b887196b5e",
+      "version": "0.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d8db60fd4857509b7f50081597e06a97e9f9568e",
       "version": "0.4.2",
       "port-version": 0

--- a/versions/p-/py-wheel.json
+++ b/versions/p-/py-wheel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f187aa45e1ccb36ac33428cb2468d30853094f7",
+      "version": "0.47.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f7e14ad62f2686e6180274082c810817ac70d59c",
       "version": "0.47.0",
       "port-version": 1

--- a/versions/v-/vcpkg-tool-mercurial.json
+++ b/versions/v-/vcpkg-tool-mercurial.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3036830cd320100be532c7e9df42604320d2b482",
+      "version-date": "2023-06-27",
+      "port-version": 1
+    },
+    {
       "git-tree": "31240d458bdb3b9ef8b86d7032aa7659455a68f5",
       "version-date": "2023-06-27",
       "port-version": 0


### PR DESCRIPTION
vcpkg-python-scripts only provides build-time CMake helpers and is never needed at runtime, so it must be a host dependency.